### PR TITLE
Light and Dark Styles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -12,8 +12,6 @@
 }
 
 body {
-  background-color: rgba(var(--accent), 0.15);
-  color: rgb(var(--base));
   font-family: "Inter VF", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
     "Segoe UI Symbol";
@@ -77,8 +75,6 @@ a:hover > span {
 blockquote {
   font-size: 0.875em;
   margin: 0;
-  background-color: rgb(var(--complimentary));
-  color: rgb(var(--light));
   padding: calc(var(--scale) * 4);
   position: relative;
   box-sizing: border-box;
@@ -91,7 +87,6 @@ blockquote:before {
   right: -1em;
   bottom: 1em;
   left: 1em;
-  border: 3px dashed rgb(var(--accent));
   z-index: -1;
 }
 
@@ -170,5 +165,50 @@ h2:before {
     grid-template-columns: 2fr minmax(400px, 1fr);
     grid-template-rows: 2fr auto;
     grid-column-gap: calc(var(--scale) * 4);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: rgb(var(--base));
+    color: rgba(var(--light), 0.85);
+  }
+
+  blockquote {
+    background-color: rgb(var(--accent));
+    color: rgb(var(--base));
+  }
+
+  blockquote:before {
+    border: 3px dashed rgb(var(--complimentary));
+  }
+
+  blockquote a {
+    background-color: rgb(var(--complimentary));
+    color: rgb(var(--accent));
+  }
+
+  h2:before {
+    background-color: rgba(var(--accent), 0.2);
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  body {
+    background-color: rgba(var(--accent), 0.15);
+    color: rgb(var(--base));
+  }
+
+  blockquote {
+    background-color: rgb(var(--complimentary));
+    color: rgb(var(--light));
+  }
+
+  blockquote:before {
+    border: 3px dashed rgb(var(--accent));
+  }
+
+  h2:before {
+    background-color: rgb(var(--accent));
   }
 }


### PR DESCRIPTION
First pass at light and dark styles.

With the colours defined for light and dark mode housed within the `preferes-color-scheme` media query - it leaves older browsers that do not support with the media query with minimal styling.  Even though I am not worried about this as it is a personal project- it would be nice to have a complete solution.

Leaving branch to return to as and when I see fit.